### PR TITLE
DataCite configuration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/datacite/DataCiteImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/datacite/DataCiteImportMetadataSourceServiceImpl.java
@@ -29,6 +29,7 @@ import org.dspace.importer.external.liveimportclient.service.LiveImportClient;
 import org.dspace.importer.external.service.AbstractImportMetadataSourceService;
 import org.dspace.importer.external.service.DoiCheck;
 import org.dspace.importer.external.service.components.QuerySource;
+import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -49,9 +50,8 @@ public class DataCiteImportMetadataSourceServiceImpl
     @Autowired
     private LiveImportClient liveImportClient;
 
-    private final int timeoutMs = 180000;
-
-    private final String url = "https://api.datacite.org/dois/";
+    @Autowired
+    private ConfigurationService configurationService;
 
     @Override
     public String getImportSource() {
@@ -95,6 +95,8 @@ public class DataCiteImportMetadataSourceServiceImpl
             id = query;
         }
         uriParameters.put("query", id);
+        int timeoutMs = configurationService.getIntProperty("datacite.timeout", 180000);
+        String url = configurationService.getProperty("datacite.url", "https://api.datacite.org/dois/");
         String responseString = liveImportClient.executeHttpGetRequest(timeoutMs, url, params);
         JsonNode jsonNode = convertStringJsonToJsonNode(responseString);
         if (jsonNode == null) {

--- a/dspace/config/modules/external-providers.cfg
+++ b/dspace/config/modules/external-providers.cfg
@@ -85,4 +85,10 @@ scopus.search-api.viewMode =
 wos.apiKey =
 wos.url = https://wos-api.clarivate.com/api/wos/id/
 wos.url.search = https://wos-api.clarivate.com/api/wos/?databaseId=WOS&lang=en&usrQuery=
-##################################################################
+#################################################################
+#------------------------- DataCite ----------------------------#
+#---------------------------------------------------------------#
+
+datacite.url = https://api.datacite.org/dois/
+datacite.timeout = 180000
+#################################################################

--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -212,4 +212,15 @@
         </property>
     </bean>
 
+    <bean id="dataciteLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="DataCiteImportService"/>
+        <property name="sourceIdentifier" value="datacite"/>
+        <property name="recordIdMetadata" value="dc.identifier.doi"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
 </beans>


### PR DESCRIPTION
Address Tim Donohue's comments at https://github.com/DSpace/DSpace/pull/8593:

* DataCite URL and timeout configured using ConfigurationService
* DataCite bean added to default configuration

The translation key has not been added.